### PR TITLE
글 수정일 표시

### DIFF
--- a/_posts/Aseprite-직접-빌드하기.md
+++ b/_posts/Aseprite-직접-빌드하기.md
@@ -1,7 +1,8 @@
 ---
 title: 'Aseprite 직접 빌드하기'
 excerpt: '오픈소스 프로그램인 Aseprite를 직접 빌드하는 방법'
-date: '2021-08-16T14:35:00.000Z'
+date: '2021-08-16T14:00:00.000Z'
+modifiedDate: '2021-08-20T14:00:00.000Z'
 ---
 
 참조 링크: [https://github.com/aseprite/aseprite/blob/main/INSTALL.md](https://github.com/aseprite/aseprite/blob/main/INSTALL.md)

--- a/components/more-stories.tsx
+++ b/components/more-stories.tsx
@@ -15,6 +15,7 @@ const MoreStories = ({ posts }: Props) => {
             key={post.slug}
             title={post.title}
             date={post.date}
+            modifiedDate={post.modifiedDate}
             slug={post.slug}
             excerpt={post.excerpt}
           />

--- a/components/post-header.tsx
+++ b/components/post-header.tsx
@@ -7,21 +7,31 @@ type Props = {
   title: string;
   coverImage?: string;
   date: string;
+  modifiedDate: string;
 };
 
-const PostHeader = ({ title, coverImage, date }: Props) => {
+const PostHeader = (post: Props) => {
   return (
     <div className="max-w-2xl mx-auto">
       <div className="mb-16">
         <div className="mx-auto">
-          <PostTitle>{title}</PostTitle>
+          <PostTitle>{post.title}</PostTitle>
         </div>
         <div className="text-sm text-right md:text-left">
-          <DateFormatter dateString={date} />
+          <div>
+            {'작성: '}
+            <DateFormatter dateString={post.date} />
+          </div>
+          <div>
+            {'수정: '}
+            <DateFormatter dateString={post.modifiedDate} />
+          </div>
         </div>
       </div>
       <div className="mb-4 md:mb-8">
-        {coverImage && <CoverImage title={title} src={coverImage} />}
+        {post.coverImage && (
+          <CoverImage title={post.title} src={post.coverImage} />
+        )}
       </div>
     </div>
   );

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -5,20 +5,28 @@ import React from 'react';
 type Props = {
   title: string;
   date: string;
+  modifiedDate: string;
   excerpt: string;
   slug: string;
 };
 
-const PostPreview = ({ title, date, excerpt, slug }: Props) => {
+const PostPreview = (post: Props) => {
   return (
-    <Link as={`/posts/${slug}`} href="/posts/[slug]" passHref>
+    <Link as={`/posts/${post.slug}`} href="/posts/[slug]" passHref>
       <a className="flex items-center w-full px-4 py-2 mx-auto overflow-hidden transition duration-100 rounded-md shadow h-36 post-item hover:shadow-lg">
         <div className="flex flex-col justify-center">
-          <h3 className="mb-1 text-2xl">{title}</h3>
+          <h3 className="mb-1 text-2xl">{post.title}</h3>
           <div className="mb-2 text-sm">
-            <DateFormatter dateString={date} />
+            <span className="mr-4">
+              {'작성: '}
+              <DateFormatter dateString={post.date} />
+            </span>
+            <span>
+              {'수정: '}
+              <DateFormatter dateString={post.modifiedDate} />
+            </span>
           </div>
-          <p className="text-base">{excerpt}</p>
+          <p className="text-base">{post.excerpt}</p>
         </div>
       </a>
     </Link>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -24,24 +24,23 @@ export function getPostBySlug(slug: string, fields: string[] = []): Items {
   const realSlug = slug.replace(/\.md$/, '');
   const fullPath = join(postsDirectory, `${realSlug}.md`);
   const fileContents = fs.readFileSync(fullPath, 'utf8');
-  const fileBirthtime = fs.statSync(fullPath).birthtime;
   const { data, content } = matter(fileContents);
 
   const items: Items = {};
 
   // Ensure only the minimal needed data is exposed
   fields.forEach((field) => {
-    if (field === 'slug') {
-      items[field] = realSlug;
-    }
-    if (field === 'content') {
-      items[field] = content;
-    }
-    if (field === 'date') {
-      items[field] = fileBirthtime.toISOString();
-    }
-    if (data[field]) {
-      items[field] = data[field];
+    switch (field) {
+      case 'slug':
+        items[field] = realSlug;
+        break;
+      case 'content':
+        items[field] = content;
+        break;
+      default:
+        if (data[field]) {
+          items[field] = data[field];
+        }
     }
   });
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -34,6 +34,7 @@ export const getStaticProps = async () => {
   const allPosts = getAllPosts([
     'title',
     'date',
+    'modifiedDate',
     'slug',
     'author',
     'coverImage',

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -47,6 +47,7 @@ const Post = ({ post, morePosts, preview }: Props) => {
                 title={post.title}
                 coverImage={post.coverImage}
                 date={post.date}
+                modifiedDate={post.modifiedDate}
               />
               <PostBody content={post.content} />
             </article>
@@ -72,6 +73,7 @@ export async function getStaticProps({ params }: Params) {
   const post = getPostBySlug(params.slug, [
     'title',
     'date',
+    'modifiedDate',
     'slug',
     'author',
     'content',

--- a/types/post.ts
+++ b/types/post.ts
@@ -2,6 +2,7 @@ type PostType = {
   slug: string;
   title: string;
   date: string;
+  modifiedDate: string;
   coverImage?: string;
   excerpt: string;
   ogImage?: {


### PR DESCRIPTION
Fixes #2

소스를 pull/push하면서 생성일(birthtime)이 바뀌는 경우가 있다. 따라서 `fs.stats.birthtime`과 `fs.stats.ctime`을 쓰는 대신 마크다운 파일 내에 `date`와 `modifiedDate`로 직접 작성하기로 했다.